### PR TITLE
Fix broken links, July 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Want to add yours? Awesome! Send a PR with your link added to the bottom of the 
 | [CWRU] | | A basic Beamer theme for Case Western Reserve University, inspired by Montpellier and created by Matt Ruffalo. |
 | [Flip] | [PDF][Flip-pdf] | A theme by Philip "Flip" Tanedo. |
 | [Ithaca] | [PDF][Ithaca-pdf] | A theme based on Flip, created by Raul Gomez. |
-| [Econ1] | [PDF][Econ1-pdf] | A theme by Rohit Patel. He also has 2 other themes for [Northwestern] and [Kellogg] students. |
 | [Gelugor] | [PDF][Gelugor-pdf] | A theme mimicking Universiti Sains Malaysia (USM)’s Powerpoint presentation template, by Lim Lian Tze. |
 | [Cyberjaya] | [PDF][Cyberjaya-pdf] | A theme mimicking Multimedia University (MMU)’s Powerpoint presentation template, by Lim Lian Tze. |
 | [Skudai] | [PDF][Skudai-pdf] | A theme mimicking Universiti Teknologi Malaysia (UTM)’s Powerpoint presentation template, by Lim Lian Tze. |
@@ -167,8 +166,6 @@ Want to add yours? Awesome! Send a PR with your link added to the bottom of the 
 [Flip-pdf]: http://www.physics.uci.edu/~tanedo/files/code/FlipBeamerTemplate.pdf
 [Ithaca]: https://pi.math.cornell.edu/~gomez/Research.html
 [Ithaca-pdf]: https://pi.math.cornell.edu/~gomez/Files/PDF/Ithacatemplate.pdf
-[Econ1]: http://www.rohit-patel.com/beamer-themes
-[Econ1-pdf]: https://www.dropbox.com/s/paapp9sev9rdl92/Econ1.pdf?dl=1
 [Northwestern]: http://www.rohit-patel.com/beamer-themes/northwestern-beamer-theme
 [Kellogg]: http://www.rohit-patel.com/beamer-themes/kellogg-beamer-theme
 [Gelugor]: http://liantze.penguinattack.org/latextypesetting.html#beamer-Gelugor

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Want to add yours? Awesome! Send a PR with your link added to the bottom of the 
 [brown]: http://git.tiker.net/brown-beamer.git
 [mit]: https://github.com/jtriley/mit-beamer
 [sthlm]: https://github.com/mholson/sthlmNordBeamerTheme
-[sthlm-pdf]: https://raw.githubusercontent.com/mholson/sthlmNordBeamerTheme/main/20150731-081156-rs2.2B-sthlmBeamerTemplate.pdf
+[sthlm-pdf]: https://github.com/mholson/sthlmNordBeamerTheme/blob/main/sthlmNordTemplate.pdf
 [rured]: https://github.com/naiaden/presentations/tree/master/rured
 [rured-pdf]: https://github.com/naiaden/presentations/raw/master/rured/example.pdf
 [kuleuven]: https://github.com/naiaden/presentations/tree/master/Leuven-9monthsprogress

--- a/README.md
+++ b/README.md
@@ -166,8 +166,6 @@ Want to add yours? Awesome! Send a PR with your link added to the bottom of the 
 [Flip-pdf]: http://www.physics.uci.edu/~tanedo/files/code/FlipBeamerTemplate.pdf
 [Ithaca]: https://pi.math.cornell.edu/~gomez/Research.html
 [Ithaca-pdf]: https://pi.math.cornell.edu/~gomez/Files/PDF/Ithacatemplate.pdf
-[Northwestern]: http://www.rohit-patel.com/beamer-themes/northwestern-beamer-theme
-[Kellogg]: http://www.rohit-patel.com/beamer-themes/kellogg-beamer-theme
 [Gelugor]: http://liantze.penguinattack.org/latextypesetting.html#beamer-Gelugor
 [Gelugor-pdf]: https://bytebucket.org/liantze/beamer-gelugor/raw/1abaa164be3db398e2d0a485e1e74d461ddc2af3/example.pdf
 [Cyberjaya]: http://liantze.penguinattack.org/latextypesetting.html#beamer-Cyberjaya


### PR DESCRIPTION
This PR

* Removes `Econ1` as the dropbox link is no longer accessible
* Removes links that are unreferenced
* Update links to sthlmNord Beamer Template which has been updated recently